### PR TITLE
Simplify dockerfile and fix GHCR attestation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  SCCACHE_GHA_ENABLED: on
 
 jobs:
   build-and-push-image:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,17 @@
 FROM rust:1.81 AS base
-RUN cargo install sccache --version '^0.7' && \
-    cargo install cargo-chef --version '^0.1'
-ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache
+RUN cargo install cargo-chef --version '^0.1'
 
 FROM base AS planner
 WORKDIR /app
 COPY . .
-RUN --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
-    cargo chef prepare --recipe-path recipe.json
+RUN cargo chef prepare --recipe-path recipe.json
 
 FROM base AS builder
 WORKDIR /app
 COPY --from=planner /app/recipe.json recipe.json
-RUN --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
-    cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
-RUN --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
-    cargo build --release
+RUN cargo build --release
 
 FROM debian:bookworm-slim
 COPY --from=builder /app/target/release/tiddly-wiki-server /srv/tiddly-wiki-server


### PR DESCRIPTION
In the GitHub build action, the sccache install step ends up being longer than the actual build and doesn't seem to be persisted across runs, so it's probably not worth keeping it.

Also fix the GHCR attestation step in the publish action.